### PR TITLE
Prepare for v1 release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - releases/*
   pull_request: {}
 
 permissions:

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
 outputs: {}
 runs:
   using: "docker"
-  image: "docker://ghcr.io/alwaysmeticulous/report-diffs-action:main"
+  image: "docker://ghcr.io/alwaysmeticulous/report-diffs-action:v1"
   env:
     API_TOKEN: ${{ inputs.api-token }}
     GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
The latest commit on the `releases/v1` branch will be tagged `v1` and published as a release.