### PR TITLE
Report number of screens that differ, rather than number of sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
-    "@alwaysmeticulous/cli": "^2.17.0",
+    "@alwaysmeticulous/cli": "^2.18.0",
     "@alwaysmeticulous/common": "^2.16.0",
     "@alwaysmeticulous/replayer": "^2.16.0"
   },

--- a/src/action.ts
+++ b/src/action.ts
@@ -67,7 +67,6 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
       useAssetsSnapshottedInBaseSimulation: false,
       parallelTasks: 8,
       deflake: false,
-      useCache: false,
       githubSummary: true,
       onTestRunCreated: (testRun) => resultsReporter.testRunStarted(testRun),
       onTestFinished: (testRun) => resultsReporter.testFinished(testRun),

--- a/src/action.ts
+++ b/src/action.ts
@@ -72,7 +72,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
       onTestRunCreated: (testRun) => resultsReporter.testRunStarted(testRun),
       onTestFinished: (testRun) => resultsReporter.testFinished(testRun),
     });
-    await resultsReporter.testRunFinished(results.testRun);
+    await resultsReporter.testRunFinished(results);
     process.exit(0);
   } catch (error) {
     const message = error instanceof Error ? error.message : `${error}`;

--- a/src/utils/results-reporter.ts
+++ b/src/utils/results-reporter.ts
@@ -88,6 +88,7 @@ export class ResultsReporter {
       await this.setCommitStatus({
         description: `Zero differences across ${totalScreens} screens tested`,
         state: "success",
+        targetUrl: testRun.url,
       });
       await this.setStatusComment({
         createIfDoesNotExist: true,

--- a/src/utils/results-reporter.ts
+++ b/src/utils/results-reporter.ts
@@ -68,7 +68,7 @@ export class ResultsReporter {
       });
     } else {
       await this.setStatusComment({
-        body: `🤖 ${METICULOUS_MARKDOWN_LINK} is replaying ${totalTestCases} sessions to check for differences: [view differences detected so far](${testRun.url}) (${percentComplete}% complete, commit: ${this.shortHeadSha})`,
+        body: `🤖 ${METICULOUS_MARKDOWN_LINK} is replaying ${totalTestCases} sessions to check for differences (${percentComplete}% complete, commit: ${this.shortHeadSha}).`,
       });
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
   dependencies:
     tunnel "^0.0.6"
 
-"@alwaysmeticulous/cli@^2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@alwaysmeticulous/cli/-/cli-2.17.0.tgz#96d41944e775db308e069e21509ac3c0117a626a"
-  integrity sha512-YkTeleL1M7uSB9VK4YOmZEikX2hUiXZFi216HHd2TZaWxBSo+6+2BZgYnbsIrzZ+9eUmLV3SPkdp86Gf896jog==
+"@alwaysmeticulous/cli@^2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@alwaysmeticulous/cli/-/cli-2.18.0.tgz#2eeda0a5bc9d388ba87311122521d89de585a372"
+  integrity sha512-IGwV+to/VjKtU6OGvXMyN25GydxAIWwz9ZXL/zrnpvUiCcgEF2G7rYC+4M9IuYGBMdwbqBlu1qhcooNDkDlHcw==
   dependencies:
     "@alwaysmeticulous/common" "^2.16.0"
     "@sentry/node" "^7.2.0"


### PR DESCRIPTION
This PR blocks on https://github.com/alwaysmeticulous/meticulous-sdk/pull/179.

The intent is that what the user sees in GitHub should line up with what they see when they click the link: if they see 6 screenshots when they click the link, then they should see the number 6 in GitHub. And if no screenshot diffs show up when they click the link, then they shouldn't see it as failed in GitHub.

In the medium/long term we'll want to better surface other kinds of errors, rather than just hide them. Designs for this in Figma.