### PR TITLE
Set a default max duration ms of 5 minutes

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -8,6 +8,8 @@ import { getCodeChangeEvent } from "./utils/get-code-change-event";
 import { getInputs } from "./utils/get-inputs";
 import { ResultsReporter } from "./utils/results-reporter";
 
+const ONE_MINUTE_IN_MS = 60 * 1_000;
+
 const DEFAULT_EXECUTION_OPTIONS: ReplayExecutionOptions = {
   headless: true,
   devTools: false,
@@ -19,7 +21,7 @@ const DEFAULT_EXECUTION_OPTIONS: ReplayExecutionOptions = {
   moveBeforeClick: false,
   disableRemoteFonts: false,
   noSandbox: true,
-  maxDurationMs: null,
+  maxDurationMs: 5 * ONE_MINUTE_IN_MS,
   maxEventCount: null,
 };
 


### PR DESCRIPTION
Setting this as part of the defaults so that users don't have to configure anything to get good out of the box settings. Note however this could be confusing if you want to run a manually recorded session that's longer than 5 minutes.

Long term when selecting sessions we should probably store the cut off point alongside the session. Then manually recorded sessions wouldn't have a cut off point associated.