### PR TITLE
set default execution maxDurationMs

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -20,7 +20,7 @@ const DEFAULT_EXECUTION_OPTIONS: ReplayExecutionOptions = {
   moveBeforeClick: false,
   disableRemoteFonts: false,
   noSandbox: true,
-  maxDurationMs: null,
+  maxDurationMs: 5 * 60 * 1_000, // 5 minutes
   maxEventCount: null,
 };
 


### PR DESCRIPTION
In the future we might want to add ability for special overrides of execution / screenshot options per test-case but for now it's safe to assume a global `maxDurationMs ` default of 5 minutes is okay for all test runs via this action.