### PR TITLE
Update permissions for publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ on:
       - published
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:


### PR DESCRIPTION
This update should fix the permissions error while pushing the `v1` tag.