### PR TITLE
Do not bail if the Meticulous action cannot run on base for PR events

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -3,7 +3,7 @@ import { context, getOctokit } from "@actions/github";
 import { initLogger, runAllTests, setLogLevel } from "@alwaysmeticulous/cli";
 import type { ReplayExecutionOptions } from "@alwaysmeticulous/common";
 import { setMeticulousLocalDataDir } from "@alwaysmeticulous/common";
-import { ensureBaseTestsExists } from "./utils/ensure-base-exists.utils";
+import { safeEnsureBaseTestsExists } from "./utils/ensure-base-exists.utils";
 import { getEnvironment } from "./utils/environment.utils";
 import { getBaseAndHeadCommitShas } from "./utils/get-base-and-head-commit-shas";
 import { getCodeChangeEvent } from "./utils/get-code-change-event";
@@ -23,6 +23,7 @@ const DEFAULT_EXECUTION_OPTIONS: ReplayExecutionOptions = {
   noSandbox: true,
   maxDurationMs: 5 * 60 * 1_000, // 5 minutes
   maxEventCount: null,
+  essentialFeaturesOnly: false,
 };
 
 const DEFAULT_SCREENSHOTTING_OPTIONS = {
@@ -61,7 +62,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
   const environment = getEnvironment({ event, head });
 
   const { currentBaseSha } =
-    (await ensureBaseTestsExists({
+    (await safeEnsureBaseTestsExists({
       event,
       apiToken,
       base,

--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -11,6 +11,21 @@ import {
   waitForWorkflowCompletion,
 } from "./workflow.utils";
 
+export const safeEnsureBaseTestsExists: typeof ensureBaseTestsExists = async (
+  ...params
+) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  try {
+    return await ensureBaseTestsExists(...params);
+  } catch (error) {
+    logger.error(error);
+    logger.log(
+      `Error while running tests on base ${params[0].base}. No diffs will be reported for this run.`
+    );
+    return null;
+  }
+};
+
 export const ensureBaseTestsExists = async ({
   event,
   apiToken,


### PR DESCRIPTION
While setting up this GitHub action for the first time, dispatching on `base` crashes the workflow; with this change we will run tests without computing diffs.