### PR TITLE
Output GH warn messages

### DIFF
--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -21,7 +21,7 @@ export const safeEnsureBaseTestsExists: typeof ensureBaseTestsExists = async (
   } catch (error) {
     logger.error(error);
     const message = `Error while running tests on base ${params[0].base}. No diffs will be reported for this run.`;
-    logger.log(message);
+    logger.warn(message);
     ghWarning(message);
     return null;
   }

--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -42,9 +42,6 @@ export const ensureBaseTestsExists = async ({
 }): Promise<{ currentBaseSha: string } | null> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  logger.warn("Test 1 2 3");
-  ghWarning("Test 1 2 3");
-
   // Running missing tests on base is only supported for Pull Request events
   if (event.type !== "pull_request" || !base) {
     return null;

--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -1,3 +1,4 @@
+import { warning as ghWarning } from "@actions/core";
 import { Context } from "@actions/github/lib/context";
 import { GitHub } from "@actions/github/lib/utils";
 import { getLatestTestRunResults } from "@alwaysmeticulous/cli";
@@ -19,9 +20,9 @@ export const safeEnsureBaseTestsExists: typeof ensureBaseTestsExists = async (
     return await ensureBaseTestsExists(...params);
   } catch (error) {
     logger.error(error);
-    logger.log(
-      `Error while running tests on base ${params[0].base}. No diffs will be reported for this run.`
-    );
+    const message = `Error while running tests on base ${params[0].base}. No diffs will be reported for this run.`;
+    logger.log(message);
+    ghWarning(message);
     return null;
   }
 };
@@ -41,6 +42,9 @@ export const ensureBaseTestsExists = async ({
 }): Promise<{ currentBaseSha: string } | null> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
+  logger.warn("Test 1 2 3");
+  ghWarning("Test 1 2 3");
+
   // Running missing tests on base is only supported for Pull Request events
   if (event.type !== "pull_request" || !base) {
     return null;
@@ -58,10 +62,10 @@ export const ensureBaseTestsExists = async ({
 
   logger.debug(JSON.stringify({ base, baseRef, currentBaseSha }, null, 2));
   if (base !== currentBaseSha) {
-    logger.warn(
-      `Pull request event received ${base} as the base commit but ${baseRef} \
-is now pointing to ${currentBaseSha}. Will use ${currentBaseSha} for Meticulous tests.`
-    );
+    const message = `Pull request event received ${base} as the base commit but ${baseRef} \
+is now pointing to ${currentBaseSha}. Will use ${currentBaseSha} for Meticulous tests.`;
+    logger.warn(message);
+    ghWarning(message);
   }
 
   const testRun = await getLatestTestRunResults({
@@ -96,9 +100,9 @@ is now pointing to ${currentBaseSha}. Will use ${currentBaseSha} for Meticulous 
   });
 
   if (workflowRun == null) {
-    logger.warn(
-      `Warning: Could not retrieve dispatched workflow run. Will not perform diffs against ${currentBaseSha}.`
-    );
+    const message = `Warning: Could not retrieve dispatched workflow run. Will not perform diffs against ${currentBaseSha}.`;
+    logger.warn(message);
+    ghWarning(message);
     return null;
   }
 


### PR DESCRIPTION
Update `console.warn` statements to also create GitHub warning annotations:

![image](https://user-images.githubusercontent.com/951086/210356361-97275113-ebed-43ca-9fe3-2dd389cc3b71.png)
