### PR TITLE
Wire through parallel tasks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
       Setting to 0 disables this feature.
     required: true
     default: 5
+  parallel-tasks:
+    description: Number of tasks to run in parallel (defaults to the number of CPUs)
+    required: false
 outputs: {}
 runs:
   using: "docker"
@@ -35,6 +38,7 @@ runs:
     APP_URL: ${{ inputs.app-url }}
     TESTS_FILE: ${{ inputs.tests-file }}
     MAX_RETRIES_ON_FAILURE: ${{ inputs.max-retries-on-failure }}
+    PARALLEL_TASKS: ${{ inputs.parallel-tasks }}
 branding:
   color: purple
   icon: camera

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: true
     default: 5
   parallel-tasks:
-    description: Number of tasks to run in parallel (defaults to the number of CPUs)
+    description: Number of tasks to run in parallel (defaults to two per CPU)
     required: false
 outputs: {}
 runs:

--- a/src/action.ts
+++ b/src/action.ts
@@ -48,8 +48,14 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
     setLogLevel("trace");
   }
 
-  const { apiToken, githubToken, appUrl, testsFile, maxRetriesOnFailure } =
-    getInputs();
+  const {
+    apiToken,
+    githubToken,
+    appUrl,
+    testsFile,
+    maxRetriesOnFailure,
+    parallelTasks,
+  } = getInputs();
   const { payload } = context;
   const event = getCodeChangeEvent(context.eventName, payload);
   const { owner, repo } = context.repo;
@@ -108,7 +114,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
       executionOptions: DEFAULT_EXECUTION_OPTIONS,
       screenshottingOptions: DEFAULT_SCREENSHOTTING_OPTIONS,
       useAssetsSnapshottedInBaseSimulation: false,
-      parallelTasks: 8,
+      parallelTasks,
       deflake: false,
       maxRetriesOnFailure,
       githubSummary: true,

--- a/src/utils/get-inputs.ts
+++ b/src/utils/get-inputs.ts
@@ -27,10 +27,22 @@ export const getInputs = () => {
     required: true,
     type: "number",
   });
+  const parallelTasks = getInputFromEnv({
+    name: "parallel-tasks",
+    required: false,
+    type: "number",
+  });
 
   const appUrl = handleLocalhostUrl(appUrl_);
 
-  return { apiToken, githubToken, appUrl, testsFile, maxRetriesOnFailure };
+  return {
+    apiToken,
+    githubToken,
+    appUrl,
+    testsFile,
+    maxRetriesOnFailure,
+    parallelTasks,
+  };
 };
 
 const DOCKER_BRIDGE_NETWORK_GATEWAY = "172.17.0.1";


### PR DESCRIPTION
I'll merge this after https://github.com/alwaysmeticulous/meticulous-sdk/pull/228 merges and I've bumped the SDK version here. Since default github runner has 2 cores, this will change the default value on default github runner from 8 parallel tasks to 4, but I think it'll be just as fast; and it should help out customers running on beefier boxes by providing a better default value.