### PR TITLE
Handle localhost aliases (#109)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   parallel-tasks:
     description: Number of tasks to run in parallel (defaults to two per CPU)
     required: false
+  localhost-aliases:
+    description: Additional aliases for localhost, as a list of comma-separated values
+    required: false
 outputs: {}
 runs:
   using: "docker"
@@ -39,6 +42,7 @@ runs:
     TESTS_FILE: ${{ inputs.tests-file }}
     MAX_RETRIES_ON_FAILURE: ${{ inputs.max-retries-on-failure }}
     PARALLEL_TASKS: ${{ inputs.parallel-tasks }}
+    LOCALHOST_ALIASES: ${{ inputs.localhost-aliases }}
 branding:
   color: purple
   icon: camera

--- a/src/action.ts
+++ b/src/action.ts
@@ -9,6 +9,7 @@ import {
 import type { ReplayExecutionOptions } from "@alwaysmeticulous/common";
 import { setMeticulousLocalDataDir } from "@alwaysmeticulous/common";
 import debounce from "lodash.debounce";
+import { addLocalhostAliases } from "./utils/add-localhost-aliases";
 import { safeEnsureBaseTestsExists } from "./utils/ensure-base-exists.utils";
 import { getEnvironment } from "./utils/environment.utils";
 import { getBaseAndHeadCommitShas } from "./utils/get-base-and-head-commit-shas";
@@ -55,6 +56,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
     testsFile,
     maxRetriesOnFailure,
     parallelTasks,
+    localhostAliases,
   } = getInputs();
   const { payload } = context;
   const event = getCodeChangeEvent(context.eventName, payload);
@@ -105,6 +107,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
         maxWait: 15_000,
       }
     );
+    await addLocalhostAliases({ appUrl, localhostAliases });
     const results = await runAllTests({
       testsFile,
       apiToken,

--- a/src/utils/add-localhost-aliases.ts
+++ b/src/utils/add-localhost-aliases.ts
@@ -1,0 +1,70 @@
+import { resolve4 } from "dns/promises";
+import { appendFile } from "fs/promises";
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import log from "loglevel";
+import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
+
+const HOSTS_FILE = "/etc/hosts";
+
+// Adds aliases intended for localhost in `/etc/hosts`, mapped instead
+// to the Docker Network bridge gateway IP address.
+export const addLocalhostAliases = async ({
+  appUrl,
+  localhostAliases,
+}: {
+  appUrl: string;
+  localhostAliases: string | null;
+}): Promise<void> => {
+  const autoDetectedAlias = await autoDetectAppURlAlias({ appUrl });
+
+  if (!localhostAliases && autoDetectedAlias == null) {
+    return;
+  }
+
+  const aliases = localhostAliases
+    ? localhostAliases.split(",").map((alias) => alias.trim())
+    : [];
+
+  const allAliases = [
+    ...aliases,
+    ...(autoDetectedAlias ? [autoDetectedAlias] : []),
+  ];
+
+  const hostsEntries = allAliases
+    .map((alias) => `${DOCKER_BRIDGE_NETWORK_GATEWAY}\t${alias}`)
+    .join("\n");
+
+  await appendFile(HOSTS_FILE, `\n${hostsEntries}`, { encoding: "utf-8" });
+};
+
+// Attempts to detect if `appUrl` is aliased to `localhost`
+const autoDetectAppURlAlias = async ({
+  appUrl,
+}: {
+  appUrl: string;
+}): Promise<string | null> => {
+  if (!appUrl) {
+    return null;
+  }
+  try {
+    const url = new URL(appUrl);
+    const ipAddresses = await resolve4(url.hostname).catch<string[]>(() => {
+      return [];
+    });
+    if (ipAddresses.every((address) => address !== "127.0.0.1")) {
+      return null;
+    }
+    // Do not alias 'localhost'
+    if (url.hostname === "localhost") {
+      return null;
+    }
+    const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+    logger.info(`Auto-detected localhost alias: ${url.hostname}`);
+    return url.hostname;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return null;
+    }
+    throw error;
+  }
+};

--- a/src/utils/get-inputs.ts
+++ b/src/utils/get-inputs.ts
@@ -32,6 +32,11 @@ export const getInputs = () => {
     required: false,
     type: "number",
   });
+  const localhostAliases = getInputFromEnv({
+    name: "localhost-aliases",
+    required: false,
+    type: "string",
+  });
 
   const appUrl = handleLocalhostUrl(appUrl_);
 
@@ -42,10 +47,11 @@ export const getInputs = () => {
     testsFile,
     maxRetriesOnFailure,
     parallelTasks,
+    localhostAliases,
   };
 };
 
-const DOCKER_BRIDGE_NETWORK_GATEWAY = "172.17.0.1";
+export const DOCKER_BRIDGE_NETWORK_GATEWAY = "172.17.0.1";
 
 // Swaps "localhost" with the IP address of the Docker host
 const handleLocalhostUrl = (appUrl: string): string => {


### PR DESCRIPTION
Add the `localhost-aliases` input to this GitHub action which lets user add aliases for localhost.