### PR TITLE
don't report different-size outcomes as differences

### DIFF
--- a/src/utils/results-reporter.ts
+++ b/src/utils/results-reporter.ts
@@ -83,8 +83,7 @@ export class ResultsReporter {
       (testCase) => testCase.screenshotDiffResults
     );
     const screensWithDifferences = screenshotDiffResults.filter(
-      (result) =>
-        result.outcome === "diff" || result.outcome === "different-size"
+      (result) => result.outcome === "diff"
     ).length;
     const totalScreens = screenshotDiffResults.length;
 


### PR DESCRIPTION
This matches the logic which we have internally for classifying differences.

Longer-term we can consider reporting on different-size outcomes / special-casing it but at the moment we treat them as `missing-head`/`missing-base`