### PR TITLE
Compare correct commits

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -73,14 +73,13 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
   const { base, head } = await getBaseAndHeadCommitShas(event);
   const environment = getEnvironment({ event, head });
 
-  const { currentBaseSha } =
-    (await safeEnsureBaseTestsExists({
-      event,
-      apiToken,
-      base,
-      context,
-      octokit,
-    })) ?? {};
+  const { shaToCompareAgainst } = await safeEnsureBaseTestsExists({
+    event,
+    apiToken,
+    base,
+    context,
+    octokit,
+  });
 
   const resultsReporter = new ResultsReporter({
     octokit,
@@ -109,7 +108,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
       testsFile,
       apiToken,
       commitSha: head,
-      baseCommitSha: currentBaseSha ?? base,
+      baseCommitSha: shaToCompareAgainst,
       appUrl,
       executionOptions: DEFAULT_EXECUTION_OPTIONS,
       screenshottingOptions: DEFAULT_SCREENSHOTTING_OPTIONS,

--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -73,6 +73,9 @@ export const ensureBaseTestsExists = async ({
     octokit,
   });
   if (alreadyPending != null) {
+    logger.log(
+      `Waiting on workflow run on base commit (${base}) to compare against: ${alreadyPending.html_url}`
+    );
     await waitForWorkflowCompletionAndThrowIfFailed({
       owner,
       repo,

--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -78,10 +78,12 @@ export const ensureBaseTestsExists = async ({
     JSON.stringify({ owner, repo, base, baseRef, currentBaseSha }, null, 2)
   );
   if (base !== currentBaseSha) {
-    const message = `Pull request event received ${base} as the base commit but ${baseRef} \
-is now pointing to ${currentBaseSha}. Will use ${currentBaseSha} for Meticulous tests. Re-running the tests will likely fix this.`;
+    const message = `Meticulous tests on base commit ${base} have either not completed or never ran so we have nothing to compare against.
+    In addition we were not able to trigger a run on ${base} since the '${baseRef}' branch is now pointing to ${currentBaseSha}.
+    Therefore no diffs will be reported for this run. Re-running the tests may fix this.`;
     logger.warn(message);
     ghWarning(message);
+    return { shaToCompareAgainst: null };
   }
 
   const testRunForHeadOfBaseBranch = await getLatestTestRunResults({

--- a/src/utils/ensure-base-exists.utils.ts
+++ b/src/utils/ensure-base-exists.utils.ts
@@ -86,29 +86,17 @@ export const ensureBaseTestsExists = async ({
     return { shaToCompareAgainst: null };
   }
 
-  const testRunForHeadOfBaseBranch = await getLatestTestRunResults({
-    client: createClient({ apiToken }),
-    commitSha: currentBaseSha,
-  });
-
-  if (testRunForHeadOfBaseBranch != null) {
-    logger.log(
-      `Tests already exist for commit ${currentBaseSha} (${testRunForHeadOfBaseBranch.id})`
-    );
-    return { shaToCompareAgainst: currentBaseSha };
-  }
-
   const workflowRun = await getOrStartNewWorkflowRun({
     owner,
     repo,
     workflowId,
     ref: baseRef,
-    commitSha: currentBaseSha,
+    commitSha: base,
     octokit,
   });
 
   if (workflowRun == null) {
-    const message = `Warning: Could not retrieve dispatched workflow run. Will not perform diffs against ${currentBaseSha}.`;
+    const message = `Warning: Could not retrieve dispatched workflow run. Will not perform diffs against ${base}.`;
     logger.warn(message);
     ghWarning(message);
     return { shaToCompareAgainst: null };
@@ -131,7 +119,7 @@ export const ensureBaseTestsExists = async ({
     );
   }
 
-  return { shaToCompareAgainst: currentBaseSha };
+  return { shaToCompareAgainst: base };
 };
 
 const getHeadCommitForRef = async ({

--- a/src/utils/workflow.utils.ts
+++ b/src/utils/workflow.utils.ts
@@ -29,7 +29,7 @@ export const getCurrentWorkflowId = async ({
   return { workflowId };
 };
 
-export const getOrStartNewWorkflowRun = async ({
+export const startNewWorkflowRun = async ({
   owner,
   repo,
   workflowId,
@@ -44,17 +44,6 @@ export const getOrStartNewWorkflowRun = async ({
   commitSha: string;
   octokit: InstanceType<typeof GitHub>;
 }): Promise<{ workflowRunId: number; [key: string]: unknown } | undefined> => {
-  const alreadyPending = await getPendingWorkflowRun({
-    owner,
-    repo,
-    workflowId,
-    commitSha,
-    octokit,
-  });
-  if (alreadyPending != null) {
-    return alreadyPending;
-  }
-
   await octokit.rest.actions.createWorkflowDispatch({
     owner,
     repo,
@@ -135,7 +124,7 @@ export const waitForWorkflowCompletion = async ({
   return workflowRun;
 };
 
-const getPendingWorkflowRun = async ({
+export const getPendingWorkflowRun = async ({
   owner,
   repo,
   workflowId,


### PR DESCRIPTION
Based on https://github.com/community/community/discussions/39880, and my own analysis, it looks like the commit GH sends us is the base commit used in GH’s temporary merge commit, not the git merge base of the branch. This means we want to always be comparing against that (and triggering test runs for it if no test run yet), not the latest commit on the main branch.