### PR TITLE
Add connection check

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -9,6 +9,7 @@ import {
 import { initSentry } from "@alwaysmeticulous/sentry";
 import debounce from "lodash.debounce";
 import { addLocalhostAliases } from "./utils/add-localhost-aliases";
+import { throwIfCannotConnectToOrigin } from "./utils/check-connection";
 import { safeEnsureBaseTestsExists } from "./utils/ensure-base-exists.utils";
 import { getEnvironment } from "./utils/environment.utils";
 import { getBaseAndHeadCommitShas } from "./utils/get-base-and-head-commit-shas";
@@ -133,6 +134,10 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
     const urlToTestAgainst = useDeploymentUrl
       ? await waitForDeploymentUrl({ owner, repo, commitSha: head, octokit })
       : appUrl;
+
+    if (urlToTestAgainst != null) {
+      await throwIfCannotConnectToOrigin(urlToTestAgainst);
+    }
 
     const results = await executeTestRun({
       testsFile,

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -4,7 +4,8 @@ import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
 export const throwIfCannotConnectToOrigin = async (url: string) => {
   const { hostname, port, protocol, origin } = new URL(url);
   const defaultPortForProtocol = protocol === "https:" ? 443 : 80;
-  const portNumber = port != null ? Number(port) : defaultPortForProtocol;
+  const portNumber =
+    port != null && port != "" ? Number(port) : defaultPortForProtocol;
   const connectionAccepted = await canConnectTo(hostname, Number(port));
   if (!connectionAccepted) {
     const rewrittenHostname = hostname.replace(

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -1,4 +1,4 @@
-import { Socket } from "net";
+import { connect } from "tls";
 import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
 
 export const throwIfCannotConnectToOrigin = async (url: string) => {
@@ -26,7 +26,10 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
 
 const canConnectTo = async (host: string, port: number, timeout = 5000) => {
   return new Promise((resolve) => {
-    const socket = new Socket();
+    const socket = connect(port, host, {}, () => {
+      socket.end();
+      resolve(true);
+    });
     const onError = () => {
       socket.destroy();
       resolve(false);
@@ -34,9 +37,5 @@ const canConnectTo = async (host: string, port: number, timeout = 5000) => {
 
     socket.setTimeout(timeout, onError);
     socket.on("error", onError);
-    socket.connect(port, host, () => {
-      socket.end();
-      resolve(true);
-    });
   });
 };

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -26,7 +26,7 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
 
 const canConnectTo = async (host: string, port: number, timeout = 5000) => {
   return new Promise((resolve) => {
-    const socket = connect(port, host, {}, () => {
+    const socket = connect(port, host, { servername: host }, () => {
       socket.end();
       resolve(true);
     });

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -6,7 +6,7 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
   const defaultPortForProtocol = protocol === "https:" ? 443 : 80;
   const portNumber =
     port != null && port != "" ? Number(port) : defaultPortForProtocol;
-  const connectionAccepted = await canConnectToHttp(hostname, portNumber);
+  const connectionAccepted = await canConnectTo(hostname, portNumber);
   if (!connectionAccepted) {
     const rewrittenHostname = hostname.replace(
       DOCKER_BRIDGE_NETWORK_GATEWAY,
@@ -24,7 +24,7 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
   }
 };
 
-const canConnectToHttp = async (host: string, port: number, timeout = 5000) => {
+const canConnectTo = async (host: string, port: number, timeout = 5000) => {
   return new Promise((resolve) => {
     const socket = new Socket();
     const onError = () => {

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -19,7 +19,7 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
     throw new Error(
       `Could not connect to '${rewrittenHostname}:${portNumber}'. Please check:\n\n` +
         `1. The server running at '${rewrittenOrigin}' has fully started by the time the Meticulous action starts. You may need to add a 'sleep 30' after starting the server to ensure that this is the case.\n` +
-        `2. The server running at '${rewrittenOrigin}' is using tcp instead of tcp6 and is bound to 0.0.0.0 rather than a specific IP address. You can use 'netstat -tulpen' to see what addresses and ports it is bound to.\n\n`
+        `2. The server running at '${rewrittenOrigin}' is using tcp instead of tcp6. You can use 'netstat -tulpen' to see what addresses and ports it is bound to.\n\n`
     );
   }
 };

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -1,5 +1,4 @@
 import { Socket } from "net";
-import { connect } from "tls";
 import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
 
 export const throwIfCannotConnectToOrigin = async (url: string) => {
@@ -7,10 +6,7 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
   const defaultPortForProtocol = protocol === "https:" ? 443 : 80;
   const portNumber =
     port != null && port != "" ? Number(port) : defaultPortForProtocol;
-  const connectionAccepted =
-    protocol === "https:"
-      ? await canConnectToHttps(hostname, portNumber)
-      : await canConnectToHttp(hostname, portNumber);
+  const connectionAccepted = await canConnectToHttp(hostname, portNumber);
   if (!connectionAccepted) {
     const rewrittenHostname = hostname.replace(
       DOCKER_BRIDGE_NETWORK_GATEWAY,
@@ -42,25 +38,5 @@ const canConnectToHttp = async (host: string, port: number, timeout = 5000) => {
       socket.end();
       resolve(true);
     });
-  });
-};
-
-const canConnectToHttps = async (
-  host: string,
-  port: number,
-  timeout = 5000
-) => {
-  return new Promise((resolve) => {
-    const socket = connect(port, host, { servername: host }, () => {
-      socket.end();
-      resolve(true);
-    });
-    const onError = () => {
-      socket.destroy();
-      resolve(false);
-    };
-
-    socket.setTimeout(timeout, onError);
-    socket.on("error", onError);
   });
 };

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -1,0 +1,41 @@
+import { Socket } from "net";
+import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
+
+export const throwIfCannotConnectToOrigin = async (url: string) => {
+  const { hostname, port, protocol, origin } = new URL(url);
+  const defaultPortForProtocol = protocol === "https:" ? 443 : 80;
+  const portNumber = port != null ? Number(port) : defaultPortForProtocol;
+  const connectionAccepted = await canConnectTo(hostname, Number(port));
+  if (!connectionAccepted) {
+    const rewrittenHostname = hostname.replace(
+      DOCKER_BRIDGE_NETWORK_GATEWAY,
+      "127.0.0.1"
+    );
+    const rewrittenOrigin = origin.replace(
+      DOCKER_BRIDGE_NETWORK_GATEWAY,
+      "127.0.0.1"
+    );
+    throw new Error(
+      `Could not connect to '${rewrittenHostname}:${portNumber}'. Please check:\n\n` +
+        `1. The server running at '${rewrittenOrigin}' has fully started by the time the Meticulous action starts. You may need to add a 'sleep 30' after starting the server to ensure that this is the case.\n` +
+        `2. The server running at '${rewrittenOrigin}' is using tcp instead of tcp6 and is bound to 0.0.0.0 rather than a specific IP address. You can use 'netstat -tulpen' to see what addresses and ports it is bound to.\n\n`
+    );
+  }
+};
+
+const canConnectTo = async (host: string, port: number, timeout = 5000) => {
+  return new Promise((resolve) => {
+    const socket = new Socket();
+    const onError = () => {
+      socket.destroy();
+      resolve(false);
+    };
+
+    socket.setTimeout(timeout, onError);
+    socket.on("error", onError);
+    socket.connect(port, host, () => {
+      socket.end();
+      resolve(true);
+    });
+  });
+};

--- a/src/utils/get-inputs.ts
+++ b/src/utils/get-inputs.ts
@@ -85,7 +85,7 @@ export const DOCKER_BRIDGE_NETWORK_GATEWAY = "172.17.0.1";
 const handleLocalhostUrl = (appUrl: string): string => {
   try {
     const url = new URL(appUrl);
-    if (url.hostname === "localhost") {
+    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
       url.hostname = DOCKER_BRIDGE_NETWORK_GATEWAY;
     }
     return url.toString();


### PR DESCRIPTION
Note: we should also catch and better handle the error if Puppeteer can't load the precise page. But this does a quick pre-check to check that a server is listening on the correct port, and we can connect to it through the Docker DOCKER_BRIDGE_NETWORK_GATEWAY IP.