### PR TITLE
Add fetch commands to fix merge-base calculation

### DIFF
--- a/src/utils/get-base-and-head-commit-shas.ts
+++ b/src/utils/get-base-and-head-commit-shas.ts
@@ -55,6 +55,9 @@ const tryGetMergeBaseOfHeadCommit = (
 ): string | null => {
   try {
     markGitDirectoryAsSafe();
+    // Only a single commit is fetched by the checkout action by default
+    // (https://github.com/actions/checkout#checkout-v3)
+    // We therefore run fetch without a `--depth` param to fetch the whole branch/commit ancestor chains, which merge-base needs
     execSync(`git fetch origin ${pullRequestHeadSha}`);
     execSync(`git fetch origin ${baseRef}`);
     const mergeBase = execSync(

--- a/src/utils/get-base-and-head-commit-shas.ts
+++ b/src/utils/get-base-and-head-commit-shas.ts
@@ -58,7 +58,7 @@ const tryGetMergeBaseOfHeadCommit = (
     execSync(`git fetch origin ${pullRequestHeadSha}`);
     execSync(`git fetch origin ${baseRef}`);
     const mergeBase = execSync(
-      `git merge-base ${pullRequestHeadSha} ${baseRef}`
+      `git merge-base ${pullRequestHeadSha} origin/${baseRef}`
     )
       .toString()
       .trim();

--- a/src/utils/get-base-and-head-commit-shas.ts
+++ b/src/utils/get-base-and-head-commit-shas.ts
@@ -55,6 +55,8 @@ const tryGetMergeBaseOfHeadCommit = (
 ): string | null => {
   try {
     markGitDirectoryAsSafe();
+    execSync(`git fetch origin ${pullRequestHeadSha}`);
+    execSync(`git fetch origin ${baseRef}`);
     const mergeBase = execSync(
       `git merge-base ${pullRequestHeadSha} ${baseRef}`
     )


### PR DESCRIPTION
Currently it's always falling back to the old way of calculating the base.