### PR TITLE
add production as allowed environment

### DIFF
--- a/.github/workflows/test-meticulous-against-deployment.yaml
+++ b/.github/workflows/test-meticulous-against-deployment.yaml
@@ -55,5 +55,6 @@ jobs:
           use-deployment-url: true
           allowed-environments: |
             Preview
+            Production
           tests-file: tests/react-bmi-calculator/meticulous.json
           test-suite-id: "test Meticulous with deployment url"


### PR DESCRIPTION
main branch `push` runs are currently timing out because of mismatched deployment env name  see https://github.com/alwaysmeticulous/report-diffs-action/actions/runs/4688337775/jobs/8308722829?pr=221 for example