### PR TITLE
Setup proxy to host instead of rewriting URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
-  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 \
+  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 nginx \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -19,6 +19,7 @@ import { getBaseAndHeadCommitShas } from "./utils/get-base-and-head-commit-shas"
 import { getCodeChangeEvent } from "./utils/get-code-change-event";
 import { getInputs } from "./utils/get-inputs";
 import { initLogger, setLogLevel, shortSha } from "./utils/logger.utils";
+import { spinUpProxyIfNeeded } from "./utils/proxy";
 import { ResultsReporter } from "./utils/results-reporter";
 import { waitForDeploymentUrl } from "./utils/wait-for-deployment-url";
 
@@ -144,6 +145,7 @@ export const runMeticulousTestsAction = async (): Promise<void> => {
       : appUrl;
 
     if (urlToTestAgainst != null) {
+      spinUpProxyIfNeeded(urlToTestAgainst, logger);
       await throwIfCannotConnectToOrigin(urlToTestAgainst);
     }
 

--- a/src/utils/__tests__/get-inputs.spec.ts
+++ b/src/utils/__tests__/get-inputs.spec.ts
@@ -78,7 +78,7 @@ describe("getInputs", () => {
 
     expect(getInputs()).toEqual({
       ...EXPECTED_DEFAULT_VALUES,
-      appUrl: "https://example.com/",
+      appUrl: "https://example.com",
       localhostAliases: "app1.local,app2.local",
       parallelTasks: 5,
       testsFile: "tests.json",
@@ -123,16 +123,6 @@ describe("getInputs", () => {
     process.env.ALLOWED_ENVIRONMENTS = "staging";
 
     expect(() => getInputs()).toThrowError();
-  });
-
-  it("handles rewriting localhost urls to the docker bridge IP", () => {
-    setupDefaultEnvVars();
-    process.env.APP_URL = "https://localhost/app";
-
-    expect(getInputs()).toEqual({
-      ...EXPECTED_DEFAULT_VALUES,
-      appUrl: "https://172.17.0.1/app",
-    });
   });
 
   const setupDefaultEnvVars = () => {

--- a/src/utils/add-localhost-aliases.ts
+++ b/src/utils/add-localhost-aliases.ts
@@ -2,7 +2,7 @@ import { resolve4 } from "dns/promises";
 import { appendFile } from "fs/promises";
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import log from "loglevel";
-import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
+import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./proxy";
 
 const HOSTS_FILE = "/etc/hosts";
 

--- a/src/utils/check-connection.ts
+++ b/src/utils/check-connection.ts
@@ -1,5 +1,4 @@
 import { Socket } from "net";
-import { DOCKER_BRIDGE_NETWORK_GATEWAY } from "./get-inputs";
 
 export const throwIfCannotConnectToOrigin = async (url: string) => {
   const { hostname, port, protocol, origin } = new URL(url);
@@ -8,18 +7,10 @@ export const throwIfCannotConnectToOrigin = async (url: string) => {
     port != null && port != "" ? Number(port) : defaultPortForProtocol;
   const connectionAccepted = await canConnectTo(hostname, portNumber);
   if (!connectionAccepted) {
-    const rewrittenHostname = hostname.replace(
-      DOCKER_BRIDGE_NETWORK_GATEWAY,
-      "127.0.0.1"
-    );
-    const rewrittenOrigin = origin.replace(
-      DOCKER_BRIDGE_NETWORK_GATEWAY,
-      "127.0.0.1"
-    );
     throw new Error(
-      `Could not connect to '${rewrittenHostname}:${portNumber}'. Please check:\n\n` +
-        `1. The server running at '${rewrittenOrigin}' has fully started by the time the Meticulous action starts. You may need to add a 'sleep 30' after starting the server to ensure that this is the case.\n` +
-        `2. The server running at '${rewrittenOrigin}' is using tcp instead of tcp6. You can use 'netstat -tulpen' to see what addresses and ports it is bound to.\n\n`
+      `Could not connect to '${hostname}:${portNumber}'. Please check:\n\n` +
+        `1. The server running at '${origin}' has fully started by the time the Meticulous action starts. You may need to add a 'sleep 30' after starting the server to ensure that this is the case.\n` +
+        `2. The server running at '${origin}' is using tcp instead of tcp6. You can use 'netstat -tulpen' to see what addresses and ports it is bound to.\n\n`
     );
   }
 };

--- a/src/utils/get-inputs.ts
+++ b/src/utils/get-inputs.ts
@@ -12,7 +12,7 @@ export const getInputs = () => {
     required: true,
     type: "string",
   });
-  const appUrl_ = getInputFromEnv({
+  const appUrl = getInputFromEnv({
     name: "app-url",
     required: false,
     type: "string",
@@ -63,7 +63,7 @@ export const getInputs = () => {
     type: "string-array",
   });
 
-  if (appUrl_ != null && appUrl_ != "" && useDeploymentUrl === true) {
+  if (appUrl != null && appUrl != "" && useDeploymentUrl === true) {
     throw new Error("Cannot use both app-url and use-deployment-url");
   }
 
@@ -80,8 +80,6 @@ export const getInputs = () => {
     );
   }
 
-  const appUrl = appUrl_ ? handleLocalhostUrl(appUrl_) : appUrl_;
-
   return {
     apiToken,
     githubToken,
@@ -96,19 +94,4 @@ export const getInputs = () => {
     testSuiteId,
     allowedEnvironments,
   };
-};
-
-export const DOCKER_BRIDGE_NETWORK_GATEWAY = "172.17.0.1";
-
-// Swaps "localhost" with the IP address of the Docker host
-const handleLocalhostUrl = (appUrl: string): string => {
-  try {
-    const url = new URL(appUrl);
-    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-      url.hostname = DOCKER_BRIDGE_NETWORK_GATEWAY;
-    }
-    return url.toString();
-  } catch (error) {
-    return appUrl;
-  }
 };

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,41 @@
+import { execSync } from "child_process";
+import { mkdirSync, writeFileSync } from "fs";
+import * as Sentry from "@sentry/node";
+import { Logger } from "loglevel";
+
+export const DOCKER_BRIDGE_NETWORK_GATEWAY = "172.17.0.1";
+
+// We are running in a docker container and need to proxy to localhost.
+// We previously just rewrote the app URL to point to the host IP, but
+// this breaks some sites that behave specially on localhost (e.g.
+// allowing auth to go ahead with HTTPS).
+export const spinUpProxyIfNeeded = (appUrl: string, logger: Logger): void => {
+  try {
+    const url = new URL(appUrl);
+    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+      const defaultPortForProtocol = url.protocol === "https:" ? 443 : 80;
+      const port = url.port || defaultPortForProtocol;
+      const nginxConfig = `
+        events {}
+        http {
+            server {
+                listen ${port};
+                server_name localhost;
+                location / {
+                    proxy_pass http://${DOCKER_BRIDGE_NETWORK_GATEWAY}:${port};
+                }
+            }
+        }
+      `;
+      mkdirSync("/etc/nginx", { recursive: true });
+      writeFileSync("/etc/nginx/nginx.conf", nginxConfig);
+      execSync("service nginx restart");
+      logger.info(
+        `Successfully set up a proxy to host machine on port ${port}`
+      );
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+    logger.error("Error while spinning up proxy", error);
+  }
+};


### PR DESCRIPTION
This should unblock customers using Auth0 which will stop the page load if it sees a non-HTTPS and non-localhost URL.

Sample run on my personal website: https://github.com/edoardopirovano/website/actions/runs/7797651026/job/21267781609

Screenshots in the test run all look good: https://app.meticulous.ai/projects/edoardopirovano/website/test-runs/tnmzLBTmNqDJqQm8LKRpMzQbFd

Viewing a simulation confirms we were hitting `localhost` and using the proxy: https://app.meticulous.ai/projects/edoardopirovano/website/simulations/ggGWCJ6kNPnbmKbtGKqpqLDTq7

Resolves ENG-862