### PR TITLE
Fix connection check now that we're using a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@sentry/node": "^7.50.0",
     "lodash.debounce": "^4.0.8",
     "loglevel": "^1.8.1",
-    "luxon": "^3.4.3"
+    "luxon": "^3.4.3",
+    "retry": "^0.13.1"
   },
   "devDependencies": {
     "@alwaysmeticulous/api": "^2.97.0",
@@ -43,6 +44,7 @@
     "@types/jest": "^27.0.3",
     "@types/lodash.debounce": "^4.0.7",
     "@types/luxon": "^3.3.2",
+    "@types/retry": "^0.12.5",
     "@types/node": "^20.2.5",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/src/utils/results-reporter.ts
+++ b/src/utils/results-reporter.ts
@@ -129,7 +129,7 @@ export class ResultsReporter {
           // Usually this means that the user has just set up Meticulous and is running it for the first time.
           await this.setStatusComment({
             createIfDoesNotExist: true,
-            body: `🤖 Meticulous replayed ${testCaseResults.length} user sessions and [took ${totalScreenshotsTaken} visual snapshots](${testRun.url}). Meticulous did not run on ${this.options.baseRef} of the ${baseRefStr} branch and so there was nothing to compare against.
+            body: `🤖 Meticulous replayed ${testCaseResults.length} user sessions and [took ${totalScreenshotsTaken} visual snapshots](${testRun.url}). Meticulous did not run on ${this.options.baseSha} of the ${baseRefStr} branch and so there was nothing to compare against.
             \nPlease merge your pull request for setting up Meticulous in CI and ensure that it’s running on push events to the ${baseRefStr} branch.`,
           });
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,6 +1772,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
   integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
+"@types/retry@^0.12.5":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.5.tgz#f090ff4bd8d2e5b940ff270ab39fd5ca1834a07e"
+  integrity sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==
+
 "@types/semver@^7.3.12":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
@@ -5296,6 +5301,11 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
After https://github.com/alwaysmeticulous/report-diffs-action/pull/386, this connection check no longer makes sense as we can always open a port to the proxy so it isn't really checking anything. Instead, let's try and actually fetch the appUrl and see if the server behind the proxy gives us _something_ back. We don't check the status code other than 502 which is what the proxy will return if it can't connect to the server since this most closely mimics the behaviour of just opening a socket that we had before.

This PR also adds in some waiting, so that we'll retry a couple of times to allow for the fact that the server to test against may take a bit of time to spin up. This should avoid the need for customers to add/tweak manual `sleep`s in their workflow.

Also, one small fix to an error message.