### PR TITLE
Set nginx server_name correctly

### DIFF
--- a/src/actions/main/utils/proxy.ts
+++ b/src/actions/main/utils/proxy.ts
@@ -28,7 +28,9 @@ export const spinUpProxyIfNeeded = (
         http {
             server {
                 listen ${port};
-                server_name localhost;
+                server_name ${
+                  appUrlAliasedToLocalhost ? url.host : "localhost"
+                };
                 location / {
                     proxy_pass http://${DOCKER_BRIDGE_NETWORK_GATEWAY}:${port};
                 }


### PR DESCRIPTION
If we're pretending to be something other than `localhost` with the reverse proxy, we need the `server_name` to be set accordingly.