### PR TITLE
Document upload-container action and reprioritise CI options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ A GitHub Action that performs visual regression testing by comparing screenshots
 
 | Action | Use Case |
 |--------|----------|
-| `upload-assets` | Upload static assets for testing **(recommended for static sites)** |
-| `cloud-compute` | Test via secure tunnel to your locally-served app |
+| `upload-assets` | Upload built static assets for Meticulous to test **(recommended for static sites)** |
+| `upload-container` | Upload a built Docker image for Meticulous to host and test **(recommended for server-rendered apps, e.g. Next.js)** |
+| `cloud-compute` | Test a locally-served app via a secure tunnel (last resort) |
 | `report-diffs-action` | Run tests in GitHub Actions runner (legacy) |
 
-> **Recommendation:** If your app can be built as static assets (HTML/JS/CSS), use `upload-assets`. It's simpler and more reliable than running a server in CI.
+> **Recommendation:** Pick the first approach that fits your app:
+> 1. **`upload-assets`** if your app can be served as a folder of static assets (HTML/JS/CSS).
+> 2. **`upload-container`** if your app is server-rendered (Next.js, Nuxt, etc.) — build a Docker image and let Meticulous host it.
+> 3. **`cloud-compute`** only if neither of the above work — it serves the app from CI and connects via a secure tunnel, which is more brittle.
 
 ## Quick Start
 
@@ -25,7 +29,38 @@ A GitHub Action that performs visual regression testing by comparing screenshots
     app-directory: "dist"  # Your build output directory
 ```
 
-### Apps Requiring a Server
+### Server-Rendered Apps (Recommended)
+
+Build a Docker image of your app and upload it. Meticulous runs the container in its own infrastructure for the duration of the test run, so no server needs to stay alive in CI.
+
+```yaml
+- uses: docker/setup-buildx-action@v3
+
+- uses: docker/build-push-action@v6
+  with:
+    context: .
+    tags: my-app:${{ github.sha }}
+    push: false
+
+- uses: alwaysmeticulous/report-diffs-action/upload-container@v1
+  with:
+    api-token: ${{ secrets.METICULOUS_API_TOKEN }}
+    image-tag: my-app:${{ github.sha }}
+    # Optional: set if your container does not respect the PORT env var
+    container-port: 3000
+    # Optional: extra env vars passed to the container at run time
+    container-env: |
+      NODE_ENV=production
+```
+
+The container must:
+- Be built for `linux/amd64`
+- Listen on the `PORT` env var (or set `container-port` to the hard-coded port)
+- Respond `2xx` to the health-check endpoint (defaults to `GET /`, override with `container-health-check-endpoint`)
+
+### Last Resort: Tunnel to a Locally-Served App
+
+Only use this if your app can't be uploaded as static assets or as a container image.
 
 ```yaml
 - name: Serve app
@@ -44,6 +79,7 @@ A GitHub Action that performs visual regression testing by comparing screenshots
 All inputs are documented in the `action.yml` files:
 
 - [`upload-assets/action.yaml`](./upload-assets/action.yaml)
+- [`upload-container/action.yml`](./upload-container/action.yml)
 - [`cloud-compute/action.yml`](./cloud-compute/action.yml)
 - [`action.yml`](./action.yml) (legacy)
 


### PR DESCRIPTION
## Summary

- Adds `upload-container` to the Available Actions table and Quick Start section, which previously didn't mention it at all.
- Reorders the recommended approaches to match the canonical docs at [app.meticulous.ai/docs/github-actions-v2](https://app.meticulous.ai/docs/github-actions-v2): `upload-assets` → `upload-container` → `cloud-compute` (last resort) → legacy.
- Adds a Quick Start example for the container path (Docker buildx + `upload-container@v1`) and demotes the cloud-compute example to a "Last resort" subsection.
- Adds `upload-container/action.yml` to the Configuration Reference list.

## Why

Customers / coding agents landing on the repo README were being steered to `cloud-compute` for any non-static app, when `upload-container` is now the recommended approach for server-rendered apps (Next.js, Nuxt, etc.). The frontend docs and onboarding guide were already updated; this brings the README in line.

## Test plan

- [ ] Render the README on GitHub and confirm the new sections render as expected
- [ ] Confirm the recommendation block, Quick Start, and Configuration Reference list are internally consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that reorder guidance and add a new example; no runtime or security-sensitive code is modified.
> 
> **Overview**
> Updates the README to **promote `upload-container` as the recommended path for server-rendered apps**, reordering guidance to prefer `upload-assets` → `upload-container` → `cloud-compute` (last resort).
> 
> Adds a Docker build + `upload-container@v1` quick-start example, demotes the tunnel-based `cloud-compute` instructions to a *last resort* section, and includes `upload-container/action.yml` in the configuration reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b4f6b4a71f63aa7095ef24a72d0ac3c3a73bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->